### PR TITLE
check pointer if not cast ex: (char*), message print all find ex: if …

### DIFF
--- a/bubulle-py/checks/misplaced_pointers.py
+++ b/bubulle-py/checks/misplaced_pointers.py
@@ -24,6 +24,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.#
 from checks._check import AbstractCheck
+import re
 
 class MisplacedPointers(AbstractCheck):
 
@@ -34,10 +35,15 @@ class MisplacedPointers(AbstractCheck):
         self.header_lines = header_lines
 
     def check_line(self, line, line_number):
-        for pointer in self.get_config()['misplaced_pointers']:
-            if pointer in line:
-                self.args = pointer
-                return 1
+        regex = self.get_config()['regex']
+        result = []
+        for matchNum, match in enumerate(re.finditer(regex, line), start=1):
+            end = match.end() if match.end() < len(line) - 1 else match.end() - 1
+            if line[end] != ')':
+                result.append(match.group())
+        if len(result):
+            self.args = ' | '.join(result)
+            return 1
         return 0
 
     def check_ast(self, ast):

--- a/bubulle-py/checks/misplaced_pointers.py
+++ b/bubulle-py/checks/misplaced_pointers.py
@@ -42,7 +42,7 @@ class MisplacedPointers(AbstractCheck):
             end = match.end() if match.end() < len(line) - 1 else match.end() - 1
             if line[end] != ')':
                 result.append(match.group())
-        if len(result):
+        if result:
             self.args = ' | '.join(result)
             return 1
         return 0

--- a/bubulle-py/checks/misplaced_pointers.py
+++ b/bubulle-py/checks/misplaced_pointers.py
@@ -23,8 +23,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.#
-from checks._check import AbstractCheck
+
 import re
+from checks._check import AbstractCheck
 
 class MisplacedPointers(AbstractCheck):
 
@@ -37,7 +38,7 @@ class MisplacedPointers(AbstractCheck):
     def check_line(self, line, line_number):
         regex = self.get_config()['regex']
         result = []
-        for matchNum, match in enumerate(re.finditer(regex, line), start=1):
+        for match in re.finditer(regex, line):
             end = match.end() if match.end() < len(line) - 1 else match.end() - 1
             if line[end] != ')':
                 result.append(match.group())

--- a/config.json
+++ b/config.json
@@ -262,17 +262,7 @@
       "id": "V3",
       "level": 1,
       "message": "Misplaced pointer: '{0}'",
-      "misplaced_pointers": [
-        "int*",
-        "double*",
-        "float*",
-        "long*",
-        "char*",
-        "string*",
-        "bool*",
-        "short*",
-        "linked_list_t*"
-      ]
+      "regex" : "(int|double|float|long|char|string|bool|short|linked_list_t)\\*{1,}"
     },
     "misplaced_spaces": {
       "enabled": true,


### PR DESCRIPTION
I changed the method for misplaced pointers.
Maintained, the pointers in parentheses are no longer marked for the casting.
The message is also more precise, it will display all of them incorrectly placed in the line
examples:
    if there is one: << have one Misplaced pointer: 'char *' >>
    if there are several: << Misplaced pointer: 'char * | int * '>>
I also added the void * which was not there 